### PR TITLE
Add support for splitting extents around zero data.

### DIFF
--- a/file/data.go
+++ b/file/data.go
@@ -147,16 +147,78 @@ func (d *fileData) truncate(ctx context.Context, s CAS, offset int64) error {
 			if err != nil {
 				return err
 			}
-			span = append(span, &extent{
+			span = append(span, splitExtent(&extent{
 				base:   last.base,
 				bytes:  offset - last.base,
 				blocks: append(keep, blks...),
-			})
+			})...)
 		}
 	}
 	d.extents = append(pre, span...)
 	d.totalBytes = offset
 	return nil
+}
+
+// splitExtent splits ext into possibly-multiple extents by removing
+// zero-valued data blocks. If there are no zero blocks, the return slice
+// contains just the original extent.
+func splitExtent(ext *extent) []*extent {
+	var chunks [][]cblock
+	var bases []int64
+	var sizes []int64
+
+	// Do a two-finger walk of the blocks. The left finger (lo) scans for the
+	// next zero-value block, and the right finger (hi) scans forward from there
+	// to find the end of the non-zero range. Along the way, we keep track of
+	// the base and size of each non-zero range, to pack into extents.
+	
+	base := ext.base
+	lo := 0
+
+nextBlock:
+	for lo < len(ext.blocks) {
+		// Scan for a nonzero block.
+		if ext.blocks[lo].key == "" {
+			base += ext.blocks[lo].bytes
+			lo++
+			continue
+		}
+
+		// Scan forward for a zero block.
+		nextBase := base + ext.blocks[lo].bytes
+		for hi := lo + 1; hi < len(ext.blocks); hi++ {
+			blk := ext.blocks[hi]
+
+			// If we found a zero-value block, the non-zero blocks since the last
+			// marker are an extent.
+			if blk.key == "" {
+				chunks = append(chunks, ext.blocks[lo:hi])
+				bases = append(bases, base)
+				sizes = append(sizes, nextBase-base)
+				base = nextBase
+				lo = hi
+				continue nextBlock
+			}
+			nextBase += blk.bytes
+		}
+
+		// If we get here, hi reached the end of the blocks without finding
+		// another zero-value block, so the rest of the blocks are an extent.
+		chunks = append(chunks, ext.blocks[lo:])
+		bases = append(bases, base)
+		sizes = append(sizes, nextBase-base)
+		break
+	}
+
+	exts := make([]*extent, len(chunks))
+	for i, chunk := range chunks {
+		exts[i] = &extent{
+			base:   bases[i],
+			bytes:  sizes[i],
+			blocks: chunk,
+		}
+	}
+	return exts
 }
 
 // writeAt writes the contents of data at the specified offset in d.  It
@@ -246,19 +308,17 @@ func (d *fileData) writeAt(ctx context.Context, s CAS, data []byte, offset int64
 	// Rather than fix it here, we rely on the normalization that happens during
 	// conversion to wire format, which includes this merge check.
 
-	d.extents = make([]*extent, len(pre)+1+len(post))
+	d.extents = make([]*extent, 0, len(pre)+1+len(post))
 	//
-	// d.extents = [ ...pre... |merged| ...post... ]
+	// d.extents = [ ...pre... | ...merged ... | ...post... ]
 	//
-	copy(d.extents, pre)
-	d.extents[len(pre)] = &extent{
+	d.extents = append(d.extents, pre...)
+	d.extents = append(d.extents, splitExtent(&extent{
 		base:   newBase,
 		bytes:  newEnd - newBase,
 		blocks: append(left, append(body, right...)...),
-	}
-	if n := copy(d.extents[len(pre)+1:], post); n != len(post) {
-		panic("safety check: incorrect allocation size")
-	}
+	})...)
+	d.extents = append(d.extents, post...)
 	if end > d.totalBytes {
 		d.totalBytes = end
 	}
@@ -329,6 +389,9 @@ func (d *fileData) readAt(ctx context.Context, s CAS, data []byte, offset int64)
 	return nr, nil
 }
 
+// splitBlobs re-blocks the concatenation of the specified blobs and returns
+// the resulting blocks. Zero-valued blocks are not stored, the caller can
+// detect this by looking for a key of "".
 func (d *fileData) splitBlobs(ctx context.Context, s CAS, blobs ...[]byte) ([]cblock, error) {
 	rs := make([]io.Reader, len(blobs))
 	for i, b := range blobs {
@@ -338,6 +401,13 @@ func (d *fileData) splitBlobs(ctx context.Context, s CAS, blobs ...[]byte) ([]cb
 
 	var blks []cblock
 	if err := block.NewSplitter(data, d.sc).Split(func(blk []byte) error {
+		// We do not store blocks of zeroes. They count against the total file
+		// size, but we do not explicitly record them.
+		if isZero(blk) {
+			blks = append(blks, cblock{bytes: int64(len(blk))})
+			return nil
+		}
+
 		key, err := s.PutCAS(ctx, blk)
 		if err != nil {
 			return err

--- a/file/wiretype/types.go
+++ b/file/wiretype/types.go
@@ -60,8 +60,11 @@ func (x *Index) Normalize() {
 	})
 	i, j := 0, 1
 	for j < len(x.Extents) {
-		// If two adjacent extents abut, merge them into the first.
-		if x.Extents[i].Base+x.Extents[i].Bytes == x.Extents[j].Base {
+		if x.Extents[i].Bytes == 0 {
+			// Remove empty extents.
+			x.Extents[i] = x.Extents[j]
+		} else if x.Extents[i].Base+x.Extents[i].Bytes == x.Extents[j].Base {
+			// If two adjacent extents abut, merge them into the first.
 			x.Extents[i].Bytes += x.Extents[j].Bytes
 			x.Extents[i].Blocks = append(x.Extents[i].Blocks, x.Extents[j].Blocks...)
 		} else {
@@ -69,6 +72,11 @@ func (x *Index) Normalize() {
 			x.Extents[i] = x.Extents[j]
 		}
 		j++
+	}
+
+	// Do an empty check on the sole or trailing extent.
+	if x.Extents[i].Bytes == 0 {
+		i--
 	}
 	x.Extents = x.Extents[:i+1]
 }


### PR DESCRIPTION
When an extent contains zero-valued blocks, it can be split at those blocks
into multiple extents. Add a function that can split a single extent by
checking its blocks for these partition points.

Related changes:

 - wiretype: Remove empty extents when normalizing an Index
 - Replace bytes.Reader with a custom reader.
 - Simplify newFileData somewhat.
