### PR TITLE
wbstore: cache non-replacement Put operations

### DIFF
--- a/storage/wbstore/wbstore_test.go
+++ b/storage/wbstore/wbstore_test.go
@@ -14,14 +14,15 @@ var _ blob.CAS = (*wbstore.Store)(nil)
 
 type slowCAS struct {
 	blob.CAS
-	next <-chan bool
+	next <-chan chan struct{}
 }
 
 func (s slowCAS) Put(ctx context.Context, opts blob.PutOptions) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-s.next:
+	case p := <-s.next:
+		defer close(p)
 		return s.CAS.Put(ctx, opts)
 	}
 }
@@ -31,7 +32,7 @@ func TestStore(t *testing.T) {
 
 	buf := memstore.New()
 	base := memstore.New()
-	next := make(chan bool, 1)
+	next := make(chan chan struct{}, 1)
 
 	s := wbstore.New(ctx, slowCAS{
 		CAS:  blob.NewCAS(base, sha1.New),
@@ -42,9 +43,19 @@ func TestStore(t *testing.T) {
 		t.Helper()
 		key, err := s.CASPut(ctx, []byte(val))
 		if err != nil {
-			t.Fatalf("Write %q failed: %v", val, err)
+			t.Fatalf("CASPut %q failed: %v", val, err)
 		}
 		return key
+	}
+	mustPut := func(key, val string, replace bool) {
+		t.Helper()
+		if err := s.Put(ctx, blob.PutOptions{
+			Key:     key,
+			Data:    []byte(val),
+			Replace: replace,
+		}); err != nil {
+			t.Fatalf("Put %q failed: %v", val, err)
+		}
 	}
 	checkVal := func(m blob.Store, key, want string) {
 		t.Helper()
@@ -57,7 +68,11 @@ func TestStore(t *testing.T) {
 			t.Errorf("Get %x: got %q, want %q", key, got, want)
 		}
 	}
-	push := func() { next <- true }
+	push := func() <-chan struct{} {
+		p := make(chan struct{})
+		next <- p
+		return p
+	}
 
 	// The base writer stalls until push is called, so we can simulate a slow
 	// write and check the contents of the buffer.
@@ -65,45 +80,49 @@ func TestStore(t *testing.T) {
 	// The test cases write a value, verify it lands in the cache, then unblock
 	// the writer and verify it lands in the base store.
 	k1 := mustWrite("foo")
-	checkVal(s, k1, "foo") // fetch against the buffer
-	checkVal(buf, k1, "foo")
-	checkVal(base, k1, "")
-	push()
+	checkVal(buf, k1, "foo") // the write should have hit the buffer
+	checkVal(base, k1, "")   // it should not have hit the base
+	<-push()
+	checkVal(base, k1, "foo")
 
 	k2 := mustWrite("bar")
-	checkVal(s, k2, "bar")
 	checkVal(buf, k2, "bar")
 	checkVal(base, k2, "")
-	push()
+	<-push()
+	checkVal(base, k2, "bar")
+
+	// A replacement Put should go directly to base, and not hit the buffer.
+	p := push()
+	mustPut("baz", "quux", true)
+	checkVal(buf, "baz", "")
+	<-p
+	checkVal(base, "baz", "quux")
+
+	// A non-replacemnt Put should hit the buffer, and not go to base.
+	mustPut("frob", "argh", false)
+	checkVal(buf, "frob", "argh")
+	checkVal(base, "frob", "")
+	<-push()
 
 	if err := s.Sync(ctx); err != nil {
 		t.Errorf("Sync: unexpected error: %v", err)
 	}
 
+	// After synchronization, everything should be in the base.
 	checkVal(base, k1, "foo")
 	checkVal(s, k1, "foo")
 	checkVal(base, k2, "bar")
 	checkVal(s, k2, "bar")
+	checkVal(base, "baz", "quux")
+	checkVal(s, "baz", "quux")
+	checkVal(base, "frob", "argh")
+	checkVal(s, "frob", "argh")
 
-	// Ordinary writes go straight to the base.
-	push()
-	if err := s.Put(ctx, blob.PutOptions{
-		Key:  "normal",
-		Data: []byte("xyzzy"),
-	}); err != nil {
-		t.Fatalf("Put failed: %v", err)
-	}
-
+	// Sync should still succeed after no further changes.
 	if err := s.Sync(ctx); err != nil {
 		t.Errorf("Sync: unexpected error: %v", err)
 	}
 
-	checkVal(buf, "normal", "")
-	checkVal(base, "normal", "xyzzy")
-
-	if err := s.Sync(ctx); err != nil {
-		t.Errorf("Sync: unexpected error: %v", err)
-	}
 	if err := s.Close(ctx); err != nil {
 		t.Errorf("Close: unexpected error: %v", err)
 	}


### PR DESCRIPTION
Previously we only cached content-addressed writes, but that meant wrappers
that modify their keys and call Put directly would not be cached.  Allow the
buffer to also capture non-replacement Put operations.

Fixes #8.