### PR TITLE
blob: require a Close method on the Store interface

### DIFF
--- a/blob/memstore/memstore.go
+++ b/blob/memstore/memstore.go
@@ -139,3 +139,6 @@ func (s *Store) Len(context.Context) (int64, error) {
 	defer s.μ.Unlock()
 	return int64(len(s.m)), nil
 }
+
+// Close implements part of blob.Store. It is a no-op here.
+func (*Store) Close(context.Context) error { return nil }

--- a/blob/store_test.go
+++ b/blob/store_test.go
@@ -15,7 +15,6 @@
 package blob_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"path"
@@ -27,39 +26,9 @@ import (
 )
 
 var (
-	errStoreClosed = errors.New("test store closed")
-
-	_ blob.CAS    = blob.HashCAS{} // satisfaction check
-	_ blob.Closer = blob.HashCAS{}
+	_ blob.Store = blob.HashCAS{} // satisfaction check
+	_ blob.CAS   = blob.HashCAS{}
 )
-
-type nonCloserStore struct{ blob.Store } // no Close method
-
-type ioCloserStore struct{ blob.Store }
-
-func (ioCloserStore) Close() error { return errStoreClosed }
-
-type blobCloserStore struct{ blob.Store }
-
-func (blobCloserStore) Close(context.Context) error { return errStoreClosed }
-
-func TestCloseStore(t *testing.T) {
-	tests := []struct {
-		store blob.Store
-		want  error
-	}{
-		{nonCloserStore{}, nil},
-		{ioCloserStore{}, errStoreClosed},
-		{blobCloserStore{}, errStoreClosed},
-	}
-
-	for _, test := range tests {
-		got := blob.CloseStore(context.Background(), test.store)
-		if got != test.want {
-			t.Errorf("CloseStore %T: got %v, want %v", test.store, got, test.want)
-		}
-	}
-}
 
 func TestSentinelErrors(t *testing.T) {
 	plain := errors.New("it's not for you")

--- a/blob/storetest/storetest.go
+++ b/blob/storetest/storetest.go
@@ -281,7 +281,7 @@ func Run(t *testing.T, s blob.Store) {
 		t.Errorf("Len at end: got %d, want 0", n)
 	}
 
-	if err := blob.CloseStore(ctx, s); err != nil {
-		t.Errorf("CloseStore failed: %v", err)
+	if err := s.Close(ctx); err != nil {
+		t.Errorf("Close failed: %v", err)
 	}
 }

--- a/storage/cachestore/cachestore.go
+++ b/storage/cachestore/cachestore.go
@@ -188,7 +188,7 @@ func (s *Store) Close(ctx context.Context) error {
 	// Release the memory held by the caches.
 	s.cache.clear()
 	s.keymap = nil
-	return blob.CloseStore(ctx, s.base)
+	return s.base.Close(ctx)
 }
 
 // CAS implements a cached wrapper around a blob.CAS instance.

--- a/storage/cachestore/cachestore_test.go
+++ b/storage/cachestore/cachestore_test.go
@@ -26,9 +26,8 @@ import (
 )
 
 var (
-	_ blob.Store  = (*cachestore.Store)(nil)
-	_ blob.Closer = (*cachestore.Store)(nil)
-	_ blob.Closer = cachestore.CAS{}
+	_ blob.Store = (*cachestore.Store)(nil)
+	_ blob.CAS   = cachestore.CAS{}
 )
 
 func TestStore(t *testing.T) {

--- a/storage/encoded/encoded.go
+++ b/storage/encoded/encoded.go
@@ -117,4 +117,4 @@ func (s *Store) List(ctx context.Context, start string, f func(string) error) er
 func (s *Store) Len(ctx context.Context) (int64, error) { return s.real.Len(ctx) }
 
 // Close implements the blob.Closer interface.
-func (s *Store) Close(ctx context.Context) error { return blob.CloseStore(ctx, s.real) }
+func (s *Store) Close(ctx context.Context) error { return s.real.Close(ctx) }

--- a/storage/filestore/filestore.go
+++ b/storage/filestore/filestore.go
@@ -177,6 +177,9 @@ func (s *Store) Len(ctx context.Context) (int64, error) {
 	return nb, nil
 }
 
+// Close implements part of blob.Store. It is a no-op here.
+func (*Store) Close(context.Context) error { return nil }
+
 func listdir(path string) ([]string, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/storage/prefixed/prefixed.go
+++ b/storage/prefixed/prefixed.go
@@ -63,9 +63,7 @@ func (s Store) unwrapKey(key string) string { return strings.TrimPrefix(key, s.p
 
 // Close implements the optional blob.Closer interface. It delegates to the
 // underlying store if possible.
-func (s Store) Close(ctx context.Context) error {
-	return blob.CloseStore(ctx, s.real)
-}
+func (s Store) Close(ctx context.Context) error { return s.real.Close(ctx) }
 
 // Get implements part of blob.Store by delegation.
 func (s Store) Get(ctx context.Context, key string) ([]byte, error) {

--- a/storage/prefixed/prefixed_test.go
+++ b/storage/prefixed/prefixed_test.go
@@ -26,9 +26,8 @@ import (
 )
 
 var (
-	_ blob.Store  = prefixed.Store{}
-	_ blob.Closer = prefixed.Store{}
-	_ blob.Closer = prefixed.CAS{}
+	_ blob.Store = prefixed.Store{}
+	_ blob.CAS   = prefixed.CAS{}
 )
 
 func TestStore(t *testing.T) {

--- a/storage/suffixed/suffixed.go
+++ b/storage/suffixed/suffixed.go
@@ -64,7 +64,7 @@ func (s Store) unwrapKey(key string) string { return strings.TrimSuffix(key, s.s
 // Close implements the optional blob.Closer interface. It delegates to the
 // underlying store if possible.
 func (s Store) Close(ctx context.Context) error {
-	return blob.CloseStore(ctx, s.real)
+	return s.real.Close(ctx)
 }
 
 // Get implements part of blob.Store by delegation.

--- a/storage/suffixed/suffixed_test.go
+++ b/storage/suffixed/suffixed_test.go
@@ -26,9 +26,8 @@ import (
 )
 
 var (
-	_ blob.Store  = suffixed.Store{}
-	_ blob.Closer = suffixed.Store{}
-	_ blob.Closer = suffixed.CAS{}
+	_ blob.Store = suffixed.Store{}
+	_ blob.CAS   = suffixed.CAS{}
 )
 
 func TestStore(t *testing.T) {

--- a/storage/wbstore/wbstore.go
+++ b/storage/wbstore/wbstore.go
@@ -96,8 +96,8 @@ func (s *Store) Close(ctx context.Context) error {
 			wberr = s.err
 		}
 	}
-	caserr := blob.CloseStore(ctx, s.CAS)
-	buferr := blob.CloseStore(ctx, s.buf)
+	caserr := s.CAS.Close(ctx)
+	buferr := s.buf.Close(ctx)
 	if wberr != nil {
 		return wberr
 	} else if caserr != nil {


### PR DESCRIPTION
Without having this method required, it is too easy for a wrapper implementation to forget to expose the optional interface needed by the delegate. At least if it is required, the implementation will have a place to add the forwarding when it turns out to be missing. That is better than the helper approach, which cannot see through the wrapping without help.