### PR TITLE
blob: redefine the CAS interface

### DIFF
--- a/file/data.go
+++ b/file/data.go
@@ -410,7 +410,7 @@ func (d *fileData) splitBlobs(ctx context.Context, s blob.CAS, blobs ...[]byte) 
 			blk = blk[:len(blk)-ztail]
 		}
 
-		key, err := s.CASPut(ctx, blk)
+		key, err := s.CASPut(ctx, blob.CASPutOptions{Data: blk})
 		if err != nil {
 			return err
 		}

--- a/file/file.go
+++ b/file/file.go
@@ -316,7 +316,7 @@ func (f *File) Truncate(ctx context.Context, offset int64) error {
 func (f *File) SetData(ctx context.Context, r io.Reader) error {
 	s := block.NewSplitter(r, f.data.sc)
 	fd, err := newFileData(s, func(data []byte) (string, error) {
-		return f.s.CASPut(ctx, data)
+		return f.s.CASPut(ctx, blob.CASPutOptions{Data: data})
 	})
 	if err != nil {
 		return err

--- a/file/wiretype/types.go
+++ b/file/wiretype/types.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/creachadair/ffs/blob"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -88,7 +89,7 @@ type Getter interface {
 
 // Putter is the interface to storage used by the Save function.
 type Putter interface {
-	CASPut(context.Context, []byte) (string, error)
+	CASPut(context.Context, blob.CASPutOptions) (string, error)
 }
 
 // Load reads the specified blob from s and decodes it into msg.
@@ -106,5 +107,5 @@ func Save(ctx context.Context, s Putter, msg proto.Message) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("encoding message: %w", err)
 	}
-	return s.CASPut(ctx, bits)
+	return s.CASPut(ctx, blob.CASPutOptions{Data: bits})
 }

--- a/storage/cachestore/cachestore.go
+++ b/storage/cachestore/cachestore.go
@@ -187,23 +187,23 @@ func NewCAS(cas blob.CAS, maxBytes int) CAS {
 }
 
 // CASPut implements part of blob.CAS using the underlying store.
-func (c CAS) CASPut(ctx context.Context, data []byte) (string, error) {
+func (c CAS) CASPut(ctx context.Context, opts blob.CASPutOptions) (string, error) {
 	c.μ.Lock()
 	defer c.μ.Unlock()
 	if err := c.initKeyMap(ctx); err != nil {
 		return "", err
 	}
 
-	key, err := c.cas.CASPut(ctx, data)
+	key, err := c.cas.CASPut(ctx, opts)
 	if err != nil {
 		return "", err
 	}
-	c.cache.put(key, data)
+	c.cache.put(key, opts.Data)
 	c.keymap.Replace(key)
 	return key, nil
 }
 
 // CASKey implements part of blob.CAS using the underlying store.
-func (c CAS) CASKey(ctx context.Context, data []byte) (string, error) {
-	return c.cas.CASKey(ctx, data)
+func (c CAS) CASKey(ctx context.Context, opts blob.CASPutOptions) (string, error) {
+	return c.cas.CASKey(ctx, opts)
 }

--- a/storage/prefixed/prefixed.go
+++ b/storage/prefixed/prefixed.go
@@ -140,26 +140,20 @@ func (c CAS) Derive(prefix string) CAS {
 	return CAS{Store: c.Store.Derive(prefix), cas: c.cas}
 }
 
+func (c CAS) setOptions(opts blob.CASPutOptions) blob.CASPutOptions {
+	return blob.CASPutOptions{
+		Data:   opts.Data,
+		Prefix: opts.Prefix + c.Store.prefix,
+		Suffix: opts.Suffix,
+	}
+}
+
 // CASPut implements part of the blob.CAS interface.
-func (c CAS) CASPut(ctx context.Context, data []byte) (string, error) {
-	if c.Store.prefix == "" {
-		return c.cas.CASPut(ctx, data)
-	}
-	key, err := c.cas.CASKey(ctx, data)
-	if err != nil {
-		return "", err
-	}
-	if err := c.Store.Put(ctx, blob.PutOptions{
-		Key:     key,
-		Data:    data,
-		Replace: false,
-	}); err != nil && !blob.IsKeyExists(err) {
-		return key, err
-	}
-	return key, nil
+func (c CAS) CASPut(ctx context.Context, opts blob.CASPutOptions) (string, error) {
+	return c.cas.CASPut(ctx, c.setOptions(opts))
 }
 
 // CASKey implements part of the blob.CAS interface.
-func (c CAS) CASKey(ctx context.Context, data []byte) (string, error) {
-	return c.cas.CASKey(ctx, data)
+func (c CAS) CASKey(ctx context.Context, opts blob.CASPutOptions) (string, error) {
+	return c.cas.CASKey(ctx, c.setOptions(opts))
 }

--- a/storage/prefixed/prefixed_test.go
+++ b/storage/prefixed/prefixed_test.go
@@ -79,9 +79,8 @@ func TestPrefixes(t *testing.T) {
 	mustPut(t, p3, "foo", "bizzle")
 	mustPut(t, p3, "zuul", "dana")
 
-	// Verify that a CAS key is properly prefixed, but that the key returned
-	// does not have the prefix.
-	ckey, err := p3.CASPut(context.Background(), []byte("hexxus"))
+	// Verify that a CAS key is properly prefixed.
+	ckey, err := p3.CASPut(context.Background(), blob.CASPutOptions{Data: []byte("hexxus")})
 	if err != nil {
 		t.Errorf("p3 CAS put: %v", err)
 	}
@@ -90,13 +89,13 @@ func TestPrefixes(t *testing.T) {
 		snap := m.Snapshot(make(map[string]string))
 
 		if diff := cmp.Diff(map[string]string{
-			"A:foo":     "bar",
-			"A:xyzzy":   "plugh",
-			"B:foo":     "quux",
-			"B:bar":     "plover",
-			"C:foo":     "bizzle",
-			"C:zuul":    "dana",   // from p3.Put
-			"C:" + ckey: "hexxus", // from p3.CASPut
+			"A:foo":   "bar",
+			"A:xyzzy": "plugh",
+			"B:foo":   "quux",
+			"B:bar":   "plover",
+			"C:foo":   "bizzle",
+			"C:zuul":  "dana",   // from p3.Put
+			ckey:      "hexxus", // from p3.CASPut
 		}, snap); diff != "" {
 			t.Errorf("Prefixed store: wrong content (-want, +got)\n%s", diff)
 		}
@@ -187,13 +186,13 @@ type selfCAS struct {
 	blob.Store
 }
 
-func (selfCAS) CASKey(_ context.Context, data []byte) (string, error) {
-	return string(data), nil
+func (selfCAS) CASKey(_ context.Context, opts blob.CASPutOptions) (string, error) {
+	return opts.Prefix + string(opts.Data) + opts.Suffix, nil
 }
 
-func (s selfCAS) CASPut(ctx context.Context, data []byte) (string, error) {
-	key := string(data)
-	err := s.Put(ctx, blob.PutOptions{Key: key, Data: data})
+func (s selfCAS) CASPut(ctx context.Context, opts blob.CASPutOptions) (string, error) {
+	key := opts.Prefix + string(opts.Data) + opts.Suffix
+	err := s.Put(ctx, blob.PutOptions{Key: key, Data: opts.Data})
 	if err != nil && !blob.IsKeyExists(err) {
 		return key, err
 	}

--- a/storage/suffixed/suffixed.go
+++ b/storage/suffixed/suffixed.go
@@ -140,26 +140,20 @@ func (c CAS) Derive(suffix string) CAS {
 	return CAS{Store: c.Store.Derive(suffix), cas: c.cas}
 }
 
+func (c CAS) setOptions(opts blob.CASPutOptions) blob.CASPutOptions {
+	return blob.CASPutOptions{
+		Data:   opts.Data,
+		Prefix: opts.Prefix,
+		Suffix: c.Store.suffix + opts.Suffix,
+	}
+}
+
 // CASPut implements part of the blob.CAS interface.
-func (c CAS) CASPut(ctx context.Context, data []byte) (string, error) {
-	if c.Store.suffix == "" {
-		return c.cas.CASPut(ctx, data)
-	}
-	key, err := c.cas.CASKey(ctx, data)
-	if err != nil {
-		return "", err
-	}
-	if err := c.Store.Put(ctx, blob.PutOptions{
-		Key:     key,
-		Data:    data,
-		Replace: false,
-	}); err != nil && !blob.IsKeyExists(err) {
-		return key, err
-	}
-	return key, nil
+func (c CAS) CASPut(ctx context.Context, opts blob.CASPutOptions) (string, error) {
+	return c.cas.CASPut(ctx, c.setOptions(opts))
 }
 
 // CASKey implements part of the blob.CAS interface.
-func (c CAS) CASKey(ctx context.Context, data []byte) (string, error) {
-	return c.cas.CASKey(ctx, data)
+func (c CAS) CASKey(ctx context.Context, opts blob.CASPutOptions) (string, error) {
+	return c.cas.CASKey(ctx, c.setOptions(opts))
 }

--- a/storage/wbstore/wbstore.go
+++ b/storage/wbstore/wbstore.go
@@ -237,19 +237,19 @@ func (s *Store) Delete(ctx context.Context, key string) error {
 
 // CASPut implements part of blob.CAS. It queries the base store for the
 // content key, but stores the blob only in the buffer.
-func (s *Store) CASPut(ctx context.Context, data []byte) (string, error) {
+func (s *Store) CASPut(ctx context.Context, opts blob.CASPutOptions) (string, error) {
 	select {
 	case <-s.exited:
 		return "", s.err
 	default:
 	}
-	key, err := s.CAS.CASKey(ctx, data)
+	key, err := s.CAS.CASKey(ctx, opts)
 	if err != nil {
 		return "", err
 	}
 	err = s.buf.Put(ctx, blob.PutOptions{
 		Key:     key,
-		Data:    data,
+		Data:    opts.Data,
 		Replace: false, // no need to replace content-addressed data
 	})
 	if blob.IsKeyExists(err) {

--- a/storage/wbstore/wbstore_test.go
+++ b/storage/wbstore/wbstore_test.go
@@ -41,7 +41,7 @@ func TestStore(t *testing.T) {
 
 	mustWrite := func(val string) string {
 		t.Helper()
-		key, err := s.CASPut(ctx, []byte(val))
+		key, err := s.CASPut(ctx, blob.CASPutOptions{Data: []byte(val)})
 		if err != nil {
 			t.Fatalf("CASPut %q failed: %v", val, err)
 		}


### PR DESCRIPTION
Allow the caller to specify prefix and suffix fragments that are to be appended
to the content address for storage. Without this, an implementation that wants
to decorate content keys in an underlying store has to make two passes: One to
generate the content key, another to store the blob.

- Update the various storage implementations in this package and their tests.
- Update usage in the file and wiretype packages.
