### PR TITLE
file: make exported methods of File and its views concurrent

### DIFF
--- a/file/file_test.go
+++ b/file/file_test.go
@@ -310,7 +310,7 @@ func TestConcurrentFile(t *testing.T) {
 	// Create a bunch of concurrent goroutines reading and writing data and
 	// metadata on the file, to expose data races.
 	var wg sync.WaitGroup
-	for i := 0; i < 500; i++ {
+	for i := 0; i < 200; i++ {
 		var buf [64]byte
 		wg.Add(1)
 		switch i % 9 {

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log"
 	"math/rand"
 	"sort"
 	"strings"
@@ -304,6 +305,7 @@ func TestConcurrentFile(t *testing.T) {
 	cas := blob.NewCAS(memstore.New(), sha1.New)
 	ctx := context.Background()
 	root := file.New(cas, nil)
+	root.Child().Set("foo", file.New(cas, nil))
 
 	// Create a bunch of concurrent goroutines reading and writing data and
 	// metadata on the file, to expose data races.
@@ -311,7 +313,7 @@ func TestConcurrentFile(t *testing.T) {
 	for i := 0; i < 500; i++ {
 		var buf [64]byte
 		wg.Add(1)
-		switch i % 5 {
+		switch i % 9 {
 		case 0:
 			// Write a block of data.
 			go func() {
@@ -340,6 +342,20 @@ func TestConcurrentFile(t *testing.T) {
 		case 4:
 			// Read data stats.
 			go func() { defer wg.Done(); _ = root.Data().Size() }()
+		case 5:
+			// Scan reachable blocks.
+			go func() { defer wg.Done(); _ = root.Scan(ctx, func(file.ScanItem) bool { return true }) }()
+		case 6:
+			// Look up a child.
+			go func() { defer wg.Done(); _ = root.Child().Has("foo") }()
+		case 7:
+			// Delete a child.
+			go func() { defer wg.Done(); root.Child().Remove("bar") }()
+		case 8:
+			// Flush the root.
+			go func() { defer wg.Done(); root.Flush(ctx) }()
+		default:
+			log.Fatalf("Incorrect test, no handler for i=%d", i)
 		}
 	}
 	wg.Wait()

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -20,9 +20,12 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math/rand"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/creachadair/ffs/blob"
 	"github.com/creachadair/ffs/blob/memstore"
@@ -295,6 +298,51 @@ and despair!`
 	}
 
 	t.Logf("Encoded node:\n%s", prototext.Format(pb.Node))
+}
+
+func TestConcurrentFile(t *testing.T) {
+	cas := blob.NewCAS(memstore.New(), sha1.New)
+	ctx := context.Background()
+	root := file.New(cas, nil)
+
+	// Create a bunch of concurrent goroutines reading and writing data and
+	// metadata on the file, to expose data races.
+	var wg sync.WaitGroup
+	for i := 0; i < 500; i++ {
+		var buf [64]byte
+		wg.Add(1)
+		switch i % 5 {
+		case 0:
+			// Write a block of data.
+			go func() {
+				defer wg.Done()
+				c := rand.Intn(len(buf))
+				nw, err := root.WriteAt(ctx, buf[:c], int64(rand.Intn(16384)))
+				if err != nil || nw != c {
+					t.Errorf("Write failed: got (%d, %v) want (%d, nil)", nw, err, c)
+				}
+			}()
+		case 1:
+			// Read a block of data.
+			go func() {
+				defer wg.Done()
+				c := rand.Intn(len(buf))
+				if _, err := root.ReadAt(ctx, buf[:c], int64(rand.Intn(16384))); err != nil && err != io.EOF {
+					t.Errorf("ReadAt failed: unexpected error %v", err)
+				}
+			}()
+		case 2:
+			// Read stat metadata.
+			go func() { defer wg.Done(); _ = root.Stat().FileInfo() }()
+		case 3:
+			// Modify stat metadata.
+			go func() { defer wg.Done(); s := root.Stat(); s.ModTime = time.Now(); s.Update() }()
+		case 4:
+			// Read data stats.
+			go func() { defer wg.Done(); _ = root.Data().Size() }()
+		}
+	}
+	wg.Wait()
 }
 
 type lineHash struct{}

--- a/file/views.go
+++ b/file/views.go
@@ -20,16 +20,23 @@ import "sort"
 type Child struct{ f *File }
 
 // Has reports whether the file has a child with the given name.
-func (c Child) Has(name string) bool { _, ok := c.f.findChild(name); return ok }
+func (c Child) Has(name string) bool {
+	c.f.mu.RLock()
+	defer c.f.mu.RUnlock()
+	_, ok := c.f.findChildLocked(name)
+	return ok
+}
 
 // Set makes kid a child of f under the given name. Set will panic if kid == nil.
 func (c Child) Set(name string, kid *File) {
 	if kid == nil {
 		panic("set: nil file")
 	}
-	defer c.f.modify()
+	c.f.mu.Lock()
+	defer c.f.mu.Unlock()
+	defer c.f.modifyLocked()
 	kid.name = name
-	if i, ok := c.f.findChild(name); ok {
+	if i, ok := c.f.findChildLocked(name); ok {
 		c.f.kids[i].File = kid // replace an existing child
 		return
 	}
@@ -45,12 +52,14 @@ func (c Child) Set(name string, kid *File) {
 }
 
 // Len returns the number of children of the file.
-func (c Child) Len() int { return len(c.f.kids) }
+func (c Child) Len() int { c.f.mu.RLock(); defer c.f.mu.RUnlock(); return len(c.f.kids) }
 
 // Remove removes name as a child of f, and reports whether a change was made.
 func (c Child) Remove(name string) bool {
-	if i, ok := c.f.findChild(name); ok {
-		defer c.f.modify()
+	c.f.mu.Lock()
+	defer c.f.mu.Unlock()
+	if i, ok := c.f.findChildLocked(name); ok {
+		defer c.f.modifyLocked()
 		c.f.kids = append(c.f.kids[:i], c.f.kids[i+1:]...)
 		return true
 	}
@@ -60,6 +69,8 @@ func (c Child) Remove(name string) bool {
 // Names returns a lexicographically ordered slice of the names of all the
 // children of the file.
 func (c Child) Names() []string {
+	c.f.mu.RLock()
+	defer c.f.mu.RUnlock()
 	out := make([]string, len(c.f.kids))
 	for i, kid := range c.f.kids {
 		out[i] = kid.Name
@@ -70,6 +81,8 @@ func (c Child) Names() []string {
 // Release discards all up-to-date cached children of the file. It returns the
 // number of records that were released.
 func (c Child) Release() int {
+	c.f.mu.Lock()
+	defer c.f.mu.Unlock()
 	var n int
 	for i, kid := range c.f.kids {
 		if kid.File != nil && kid.Key != "" && kid.Key == kid.File.key {
@@ -84,10 +97,12 @@ func (c Child) Release() int {
 type Data struct{ f *File }
 
 // Size returns the effective size of the file content in bytes.
-func (d Data) Size() int64 { return d.f.data.totalBytes }
+func (d Data) Size() int64 { d.f.mu.RLock(); defer d.f.mu.RUnlock(); return d.f.data.totalBytes }
 
 // Len returns the number of data blocks for the file.
-func (d Data) Len() int {
+func (d Data) Len() int { d.f.mu.RLock(); defer d.f.mu.RUnlock(); return d.lenLocked() }
+
+func (d Data) lenLocked() int {
 	var nb int
 	for _, e := range d.f.data.extents {
 		nb += len(e.blocks)
@@ -98,7 +113,9 @@ func (d Data) Len() int {
 // Keys returns the storage keys of the data blocks for the file.  If the file
 // has no binary data, the slice is empty.
 func (d Data) Keys() []string {
-	nb := d.Len()
+	d.f.mu.RLock()
+	defer d.f.mu.RUnlock()
+	nb := d.lenLocked()
 	if nb == 0 {
 		return nil
 	}
@@ -115,28 +132,42 @@ func (d Data) Keys() []string {
 type XAttr struct{ f *File }
 
 // Has reports whether the specified attribute is defined.
-func (x XAttr) Has(key string) bool { _, ok := x.f.xattr[key]; return ok }
+func (x XAttr) Has(key string) bool {
+	x.f.mu.RLock()
+	defer x.f.mu.RUnlock()
+	_, ok := x.f.xattr[key]
+	return ok
+}
 
 // Get returns the value corresponding to the given key, or "" if the key is
 // not defined.
-func (x XAttr) Get(key string) string { return x.f.xattr[key] }
+func (x XAttr) Get(key string) string { x.f.mu.RLock(); defer x.f.mu.RUnlock(); return x.f.xattr[key] }
 
 // Set sets the specified xattr.
-func (x XAttr) Set(key, value string) { defer x.f.inval(); x.f.xattr[key] = value }
+func (x XAttr) Set(key, value string) {
+	x.f.mu.Lock()
+	defer x.f.mu.Unlock()
+	defer x.f.invalLocked()
+	x.f.xattr[key] = value
+}
 
 // Len reports the number of extended attributes defined on f.
-func (x XAttr) Len() int { return len(x.f.xattr) }
+func (x XAttr) Len() int { x.f.mu.RLock(); defer x.f.mu.RUnlock(); return len(x.f.xattr) }
 
 // Remove removes the specified xattr.
 func (x XAttr) Remove(key string) {
-	if x.Has(key) {
+	x.f.mu.Lock()
+	defer x.f.mu.Unlock()
+	if _, ok := x.f.xattr[key]; ok {
 		delete(x.f.xattr, key)
-		x.f.inval()
+		x.f.invalLocked()
 	}
 }
 
 // Names returns a slice of the names of all the extended attributes defined.
 func (x XAttr) Names() []string {
+	x.f.mu.RLock()
+	defer x.f.mu.RUnlock()
 	names := make([]string, 0, len(x.f.xattr))
 	for key := range x.f.xattr {
 		names = append(names, key)
@@ -147,8 +178,10 @@ func (x XAttr) Names() []string {
 
 // Clear removes all the extended attributes set on the file.
 func (x XAttr) Clear() {
+	x.f.mu.Lock()
+	defer x.f.mu.Unlock()
 	if len(x.f.xattr) != 0 {
-		defer x.f.inval()
+		defer x.f.invalLocked()
 		x.f.xattr = make(map[string]string)
 	}
 }

--- a/file/views.go
+++ b/file/views.go
@@ -182,6 +182,6 @@ func (x XAttr) Clear() {
 	defer x.f.mu.Unlock()
 	if len(x.f.xattr) != 0 {
 		defer x.f.invalLocked()
-		x.f.xattr = make(map[string]string)
+		clear(x.f.xattr)
 	}
 }


### PR DESCRIPTION
Add a mutex to the File value, and acquire it where necessary to allow
concurrent use by multiple goroutines. Add a test to exercise some of the most
common cases of this.
