### PR TITLE
blob: rename Store to KV

### DIFF
--- a/blob/memstore/memstore.go
+++ b/blob/memstore/memstore.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package memstore implements the blob.Store interface using a map.
+// Package memstore implements the [blob.KV] interface using a map.
 package memstore
 
 import (
@@ -25,10 +25,10 @@ import (
 	"github.com/creachadair/mds/stree"
 )
 
-// Store implements the blob.Store interface using an in-memory dictionary. The
+// KV implements the [blob.KV] interface using an in-memory dictionary. The
 // contents of a Store are not persisted. All operations on a memstore are safe
 // for concurrent use by multiple goroutines.
-type Store struct {
+type KV struct {
 	μ sync.Mutex
 	m *stree.Tree[entry]
 }
@@ -43,13 +43,13 @@ func compareEntries(a, b entry) int { return strings.Compare(a.key, b.key) }
 
 // Opener constructs a memstore, for use with the store package.  The address
 // is ignored, and an error will never be returned.
-func Opener(_ context.Context, _ string) (blob.Store, error) { return New(), nil }
+func Opener(_ context.Context, _ string) (blob.KV, error) { return New(), nil }
 
 // New constructs a new, empty store.
-func New() *Store { return &Store{m: stree.New(300, compareEntries)} }
+func New() *KV { return &KV{m: stree.New(300, compareEntries)} }
 
 // Clear removes all keys and values from s.
-func (s *Store) Clear() {
+func (s *KV) Clear() {
 	s.μ.Lock()
 	defer s.μ.Unlock()
 	s.m.Clear()
@@ -58,7 +58,7 @@ func (s *Store) Clear() {
 // Snapshot copies a snapshot of the keys and values of s into m.
 // If m == nil, a new empty map is allocated and returned.
 // It returns m to allow chaining with construction.
-func (s *Store) Snapshot(m map[string]string) map[string]string {
+func (s *KV) Snapshot(m map[string]string) map[string]string {
 	if m == nil {
 		m = make(map[string]string)
 	}
@@ -72,7 +72,7 @@ func (s *Store) Snapshot(m map[string]string) map[string]string {
 
 // Init replaces the contents of s with the keys and values in m.
 // It returns s to permit chaining with construction.
-func (s *Store) Init(m map[string]string) *Store {
+func (s *KV) Init(m map[string]string) *KV {
 	s.μ.Lock()
 	defer s.μ.Unlock()
 	s.m.Clear()
@@ -82,8 +82,8 @@ func (s *Store) Init(m map[string]string) *Store {
 	return s
 }
 
-// Get implements part of blob.Store.
-func (s *Store) Get(_ context.Context, key string) ([]byte, error) {
+// Get implements part of [blob.KV].
+func (s *KV) Get(_ context.Context, key string) ([]byte, error) {
 	s.μ.Lock()
 	defer s.μ.Unlock()
 
@@ -93,8 +93,8 @@ func (s *Store) Get(_ context.Context, key string) ([]byte, error) {
 	return nil, blob.KeyNotFound(key)
 }
 
-// Put implements part of blob.Store.
-func (s *Store) Put(_ context.Context, opts blob.PutOptions) error {
+// Put implements part of [blob.KV].
+func (s *KV) Put(_ context.Context, opts blob.PutOptions) error {
 	s.μ.Lock()
 	defer s.μ.Unlock()
 
@@ -107,8 +107,8 @@ func (s *Store) Put(_ context.Context, opts blob.PutOptions) error {
 	return nil
 }
 
-// Size implements part of blob.Store.
-func (s *Store) Size(_ context.Context, key string) (int64, error) {
+// Size implements part of [blob.KV].
+func (s *KV) Size(_ context.Context, key string) (int64, error) {
 	s.μ.Lock()
 	defer s.μ.Unlock()
 
@@ -118,8 +118,8 @@ func (s *Store) Size(_ context.Context, key string) (int64, error) {
 	return 0, blob.KeyNotFound(key)
 }
 
-// Delete implements part of blob.Store.
-func (s *Store) Delete(_ context.Context, key string) error {
+// Delete implements part of [blob.KV].
+func (s *KV) Delete(_ context.Context, key string) error {
 	s.μ.Lock()
 	defer s.μ.Unlock()
 
@@ -129,8 +129,8 @@ func (s *Store) Delete(_ context.Context, key string) error {
 	return nil
 }
 
-// List implements part of blob.Store.
-func (s *Store) List(_ context.Context, start string, f func(string) error) error {
+// List implements part of [blob.KV].
+func (s *KV) List(_ context.Context, start string, f func(string) error) error {
 	s.μ.Lock()
 	defer s.μ.Unlock()
 
@@ -144,12 +144,12 @@ func (s *Store) List(_ context.Context, start string, f func(string) error) erro
 	return nil
 }
 
-// Len implements part of blob.Store.
-func (s *Store) Len(context.Context) (int64, error) {
+// Len implements part of [blob.KV].
+func (s *KV) Len(context.Context) (int64, error) {
 	s.μ.Lock()
 	defer s.μ.Unlock()
 	return int64(s.m.Len()), nil
 }
 
-// Close implements part of blob.Store. It is a no-op here.
-func (*Store) Close(context.Context) error { return nil }
+// Close implements part of [blob.KV]. It is a no-op here.
+func (*KV) Close(context.Context) error { return nil }

--- a/blob/store_test.go
+++ b/blob/store_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 var (
-	_ blob.Store = blob.HashCAS{} // satisfaction check
-	_ blob.CAS   = blob.HashCAS{}
+	_ blob.KV  = blob.HashCAS{} // satisfaction check
+	_ blob.CAS = blob.HashCAS{}
 )
 
 func TestSentinelErrors(t *testing.T) {
@@ -130,7 +130,7 @@ func TestListSyncKeyer(t *testing.T) {
 		"4": "four",
 		"5": "five",
 	})
-	sk := blob.ListSyncKeyer{Store: m}
+	sk := blob.ListSyncKeyer{KV: m}
 	ctx := context.Background()
 	check := func(t *testing.T, keys []string, want ...string) {
 		t.Helper()

--- a/blob/storetest/storetest.go
+++ b/blob/storetest/storetest.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package storetest provides correctness tests for implementations of the
-// blob.Store interface.
+// [blob.KV] interface.
 package storetest
 
 import (
@@ -30,7 +30,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-type op = func(context.Context, *testing.T, blob.Store)
+type op = func(context.Context, *testing.T, blob.KV)
 
 var script = []op{
 	// Verify that the store is initially empty.
@@ -102,7 +102,7 @@ var delScript = []op{
 }
 
 func opGet(key, want string, werr error) op {
-	return func(ctx context.Context, t *testing.T, s blob.Store) {
+	return func(ctx context.Context, t *testing.T, s blob.KV) {
 		t.Helper()
 		got, err := s.Get(ctx, key)
 		if !errorOK(err, werr) {
@@ -114,7 +114,7 @@ func opGet(key, want string, werr error) op {
 }
 
 func opPut(key, data string, replace bool, werr error) op {
-	return func(ctx context.Context, t *testing.T, s blob.Store) {
+	return func(ctx context.Context, t *testing.T, s blob.KV) {
 		t.Helper()
 		err := s.Put(ctx, blob.PutOptions{
 			Key:     key,
@@ -128,7 +128,7 @@ func opPut(key, data string, replace bool, werr error) op {
 }
 
 func opDelete(key string, werr error) op {
-	return func(ctx context.Context, t *testing.T, s blob.Store) {
+	return func(ctx context.Context, t *testing.T, s blob.KV) {
 		t.Helper()
 		err := s.Delete(ctx, key)
 		if !errorOK(err, werr) {
@@ -142,7 +142,7 @@ func opList(from string, want ...string) op {
 }
 
 func opListRange(from, to string, want ...string) op {
-	return func(ctx context.Context, t *testing.T, s blob.Store) {
+	return func(ctx context.Context, t *testing.T, s blob.KV) {
 		t.Helper()
 		var got []string
 		err := s.List(ctx, from, func(key string) error {
@@ -162,7 +162,7 @@ func opListRange(from, to string, want ...string) op {
 }
 
 func opLen(want int64) op {
-	return func(ctx context.Context, t *testing.T, s blob.Store) {
+	return func(ctx context.Context, t *testing.T, s blob.KV) {
 		t.Helper()
 		got, err := s.Len(ctx)
 		if err != nil {
@@ -183,7 +183,7 @@ func errorOK(err, werr error) bool {
 
 // Run applies the test script to empty store s, then closes s.  Any errors are
 // reported to t.  After Run returns, the contents of s are garbage.
-func Run(t *testing.T, s blob.Store) {
+func Run(t *testing.T, s blob.KV) {
 	ctx := context.Background()
 	for _, op := range script {
 		op(ctx, t, s)

--- a/storage/affixed/affixed_test.go
+++ b/storage/affixed/affixed_test.go
@@ -30,7 +30,7 @@ var (
 	_ blob.CAS = affixed.CAS{}
 )
 
-func TestStore(t *testing.T) {
+func TestKV(t *testing.T) {
 	m := memstore.New()
 	p := affixed.New(m).Derive("POG:", ":CHAMP")
 	storetest.Run(t, p)

--- a/storage/affixed/affixed_test.go
+++ b/storage/affixed/affixed_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 var (
-	_ blob.Store = affixed.Store{}
-	_ blob.CAS   = affixed.CAS{}
+	_ blob.KV  = affixed.KV{}
+	_ blob.CAS = affixed.CAS{}
 )
 
 func TestStore(t *testing.T) {
@@ -36,7 +36,7 @@ func TestStore(t *testing.T) {
 	storetest.Run(t, p)
 }
 
-func mustPut(t *testing.T, s blob.Store, key, val string) {
+func mustPut(t *testing.T, s blob.KV, key, val string) {
 	t.Helper()
 	if err := s.Put(context.Background(), blob.PutOptions{
 		Key:     key,
@@ -47,7 +47,7 @@ func mustPut(t *testing.T, s blob.Store, key, val string) {
 	}
 }
 
-func mustGet(t *testing.T, s blob.Store, key, val string) {
+func mustGet(t *testing.T, s blob.KV, key, val string) {
 	t.Helper()
 	if got, err := s.Get(context.Background(), key); err != nil {
 		t.Errorf("Get %q failed: %v", key, err)
@@ -56,7 +56,7 @@ func mustGet(t *testing.T, s blob.Store, key, val string) {
 	}
 }
 
-func runList(p blob.Store, want ...string) func(t *testing.T) {
+func runList(p blob.KV, want ...string) func(t *testing.T) {
 	return func(t *testing.T) {
 		var got []string
 		if err := p.List(context.Background(), "", func(key string) error {
@@ -139,7 +139,7 @@ func TestLen(t *testing.T) {
 	mustPut(t, p2, "mango", "2")
 
 	tests := []struct {
-		store blob.Store
+		store blob.KV
 		want  int64
 	}{
 		{m, 6},  // base store: all the keys
@@ -208,7 +208,7 @@ func TestNesting(t *testing.T) {
 }
 
 type selfCAS struct {
-	blob.Store
+	blob.KV
 }
 
 func (selfCAS) CASKey(_ context.Context, opts blob.CASPutOptions) (string, error) {

--- a/storage/cachestore/cachestore_test.go
+++ b/storage/cachestore/cachestore_test.go
@@ -26,11 +26,11 @@ import (
 )
 
 var (
-	_ blob.Store = (*cachestore.Store)(nil)
-	_ blob.CAS   = cachestore.CAS{}
+	_ blob.KV  = (*cachestore.KV)(nil)
+	_ blob.CAS = cachestore.CAS{}
 )
 
-func TestStore(t *testing.T) {
+func TestKV(t *testing.T) {
 	m := memstore.New()
 	c := cachestore.New(m, 100)
 	storetest.Run(t, c)

--- a/storage/wbstore/wbstore_test.go
+++ b/storage/wbstore/wbstore_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-var _ blob.CAS = (*wbstore.Store)(nil)
+var _ blob.CAS = (*wbstore.CAS)(nil)
 
 type slowCAS struct {
 	blob.CAS
@@ -59,7 +59,7 @@ func TestStore(t *testing.T) {
 			t.Fatalf("Put %q failed: %v", val, err)
 		}
 	}
-	checkVal := func(m blob.Store, key, want string) {
+	checkVal := func(m blob.KV, key, want string) {
 		t.Helper()
 		bits, err := m.Get(ctx, key)
 		if blob.IsKeyNotFound(err) && want == "" {
@@ -70,7 +70,7 @@ func TestStore(t *testing.T) {
 			t.Errorf("Get %x: got %q, want %q", key, got, want)
 		}
 	}
-	checkLen := func(m blob.Store, want int) {
+	checkLen := func(m blob.KV, want int) {
 		t.Helper()
 		got, err := m.Len(ctx)
 		if err != nil {
@@ -79,7 +79,7 @@ func TestStore(t *testing.T) {
 			t.Errorf("Len: got %d, want %d", got, want)
 		}
 	}
-	checkList := func(m blob.Store, want ...string) {
+	checkList := func(m blob.KV, want ...string) {
 		t.Helper()
 		sort.Strings(want)
 		var got []string


### PR DESCRIPTION
We would like to use the name "Store" for a higher-level collection of
key-value buckets. As a first step, rename the "Store" interface, which itself
expresses a single key-value bucket, to "KV".

Future changes will introduce a new Store type that grants access to buckets.
In addition, I would like to break the nesting of CAS around KV, but for now I
have left the existing structure in place.
