### PR TITLE
file: fix the Scan method to allow modification

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -380,9 +380,6 @@ type ScanItem struct {
 func (f *File) Scan(ctx context.Context, visit func(ScanItem) bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if _, err := f.recFlushLocked(ctx, nil); err != nil {
-		return err
-	}
 	return f.recScanLocked(ctx, "", func(s ScanItem) bool {
 		// Yield the lock while the caller visitor runs, then reacquire it.  We
 		// do this so that the visitor can use methods that may themselves update

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -174,10 +174,16 @@ func TestScan(t *testing.T) {
 		t.Errorf("Scan result: %q, should be sorted", got)
 	}
 
-	if _, err := root.Flush(ctx); err != nil {
+	key, err := root.Flush(ctx)
+	if err != nil {
 		t.Fatalf("Flush failed: %v", err)
 	}
-	if err := root.Scan(ctx, func(e file.ScanItem) bool {
+
+	alt, err := file.Open(ctx, cas, key)
+	if err != nil {
+		t.Fatalf("Open %x failed: %v", key, err)
+	}
+	if err := alt.Scan(ctx, func(e file.ScanItem) bool {
 		if got := e.File.XAttr().Get("name"); got != e.Name {
 			t.Errorf("File %p name: got %q, want %q", e.File, got, e.Name)
 		}

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -164,14 +164,26 @@ func TestScan(t *testing.T) {
 
 	var got []string
 	if err := root.Scan(ctx, func(e file.ScanItem) bool {
+		e.File.XAttr().Set("name", e.Name)
 		got = append(got, e.Name)
 		return true
 	}); err != nil {
 		t.Fatalf("Scan failed: %v", err)
 	}
-
 	if !sort.StringsAreSorted(got) {
 		t.Errorf("Scan result: %q, should be sorted", got)
+	}
+
+	if _, err := root.Flush(ctx); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+	if err := root.Scan(ctx, func(e file.ScanItem) bool {
+		if got := e.File.XAttr().Get("name"); got != e.Name {
+			t.Errorf("File %p name: got %q, want %q", e.File, got, e.Name)
+		}
+		return true
+	}); err != nil {
+		t.Errorf("Scan failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
Previously, the Scan was implicitly read-only, not holding locks except to
capture a view of the children of a file. This was safe, because the views of a
file already use locking where necessary, but makes a Scan unable to mutate the
state of a file.

Children of a file not already loaded into memory are loaded, but the Scan was
doing this unconditionally. For reading this does not matter, but when writing
it means we lose the connection between what the view provides and what the
parent believes the state of that child is.

So here there are three fixes:

1. Run the whole scan using the correct lock chaining, as Flush.
2. Only Open files not already present.
3. Update the parent for opened files mutated by the visitor.
