### PR TITLE
blob: add a Stat method to the KVCore interface

### DIFF
--- a/blob/memstore/memstore.go
+++ b/blob/memstore/memstore.go
@@ -163,6 +163,19 @@ func (s *KV) Get(_ context.Context, key string) ([]byte, error) {
 	return nil, blob.KeyNotFound(key)
 }
 
+// Stat implements part of [blob.KV].
+func (s *KV) Stat(_ context.Context, keys ...string) (blob.StatMap, error) {
+	s.μ.Lock()
+	defer s.μ.Unlock()
+	out := make(blob.StatMap)
+	for _, key := range keys {
+		if e, ok := s.m.Get(entry{key: key}); ok {
+			out[key] = blob.Stat{Size: int64(len(e.val))}
+		}
+	}
+	return out, nil
+}
+
 // Put implements part of [blob.KV].
 func (s *KV) Put(_ context.Context, opts blob.PutOptions) error {
 	s.μ.Lock()

--- a/blob/store.go
+++ b/blob/store.go
@@ -84,6 +84,12 @@ type KVCore interface {
 	// found in the store, Get must report an ErrKeyNotFound error.
 	Get(ctx context.Context, key string) ([]byte, error)
 
+	// Stat reports the status of the specified blobs in the store.  The result
+	// map contains one entry for each requested key that is present in the
+	// store. If none of the requested keys is present, the resulting map may be
+	// either empty or nil.
+	Stat(ctx context.Context, keys ...string) (StatMap, error)
+
 	// Delete atomically removes a blob from the store. If the key is not found
 	// in the store, Delete must report an ErrKeyNotFound error.
 	Delete(ctx context.Context, key string) error
@@ -207,6 +213,18 @@ func KeyNotFound(key string) error { return &KeyError{Key: key, Err: ErrKeyNotFo
 // KeyExists returns an ErrKeyExists error reporting that key exists in the store.
 // The concrete type is *blob.KeyError.
 func KeyExists(key string) error { return &KeyError{Key: key, Err: ErrKeyExists} }
+
+// StatMap reports metadata about a collection of key-value pairs.
+type StatMap map[string]Stat
+
+// Has reports whether key is present in s.  It is a convenience wrapper for a
+// map lookup.
+func (s StatMap) Has(key string) bool { _, ok := s[key]; return ok }
+
+// Stat reports metadata about a single blob.
+type Stat struct {
+	Size int64 // the size in bytes of the value (if present)
+}
 
 // A HashCAS is a content-addressable wrapper that adds the CAS methods to a
 // delegated [KV].

--- a/storage/encoded/encoded.go
+++ b/storage/encoded/encoded.go
@@ -120,6 +120,22 @@ func (s KV) Get(ctx context.Context, key string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// Stat implements part of the [blob.KV] interface.
+func (s KV) Stat(ctx context.Context, keys ...string) (blob.StatMap, error) {
+	sts, err := s.real.Stat(ctx, keys...)
+	if err != nil {
+		return nil, err
+	}
+	for key := range sts {
+		data, err := s.Get(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		sts[key] = blob.Stat{Size: int64(len(data))}
+	}
+	return sts, nil
+}
+
 // Put implements part of the [blob.KV] interface.
 func (s KV) Put(ctx context.Context, opts blob.PutOptions) error {
 	buf := bytes.NewBuffer(make([]byte, 0, len(opts.Data)))


### PR DESCRIPTION
Now that CAS computation is all done at the leaves, it is once again useful to
have a way for the implementation to check presence before sending a full blob.

But instead of simply restoring the original Size method, which took one key at
a time, we can address both this and the "sync" case by having a variadic Stat
that also reports presence for multiple keys.

Update the default store implementations and tests.
