### PR TITLE
blob: rework Stat into a plain existence check, rename to Has

### DIFF
--- a/blob/memstore/memstore.go
+++ b/blob/memstore/memstore.go
@@ -163,14 +163,14 @@ func (s *KV) Get(_ context.Context, key string) ([]byte, error) {
 	return nil, blob.KeyNotFound(key)
 }
 
-// Stat implements part of [blob.KV].
-func (s *KV) Stat(_ context.Context, keys ...string) (blob.StatMap, error) {
+// Has implements part of [blob.KV].
+func (s *KV) Has(_ context.Context, keys ...string) (blob.KeySet, error) {
 	s.μ.Lock()
 	defer s.μ.Unlock()
-	out := make(blob.StatMap)
+	out := make(blob.KeySet)
 	for _, key := range keys {
-		if e, ok := s.m.Get(entry{key: key}); ok {
-			out[key] = blob.Stat{Size: int64(len(e.val))}
+		if _, ok := s.m.Get(entry{key: key}); ok {
+			out.Add(key)
 		}
 	}
 	return out, nil

--- a/blob/storetest/storetest.go
+++ b/blob/storetest/storetest.go
@@ -203,16 +203,10 @@ func Run(t *testing.T, s blob.StoreCloser) {
 			}
 
 			// Verify that the edits to k1 gave the expected result.
-			st, err := k1.Stat(ctx, "fruit", "animal", "beverage", "nut", "nonesuch", "0")
+			st, err := k1.Has(ctx, "fruit", "animal", "beverage", "nut", "nonesuch", "0")
 			if err != nil {
 				t.Errorf("KV 1 stat: unexpected error: %v", err)
-			} else if diff := gocmp.Diff(st, blob.StatMap{
-				"0":        {Size: 10},
-				"animal":   {Size: 6},
-				"fruit":    {Size: 4},
-				"nut":      {Size: 8},
-				"beverage": {Size: 12}, // ñ is two bytes
-			}); diff != "" {
+			} else if diff := gocmp.Diff(st, mapset.New("0", "animal", "fruit", "nut", "beverage")); diff != "" {
 				t.Errorf("KV 1 stat (-got, +want):\n%s", diff)
 			}
 

--- a/storage/cachestore/cachestore.go
+++ b/storage/cachestore/cachestore.go
@@ -142,18 +142,18 @@ func (s *KV) getLocked(ctx context.Context, key string) ([]byte, bool, error) {
 	return data, ok, nil
 }
 
-// Stat implements a method of [blob.KV].
-func (s *KV) Stat(ctx context.Context, keys ...string) (blob.StatMap, error) {
+// Has implements a method of [blob.KV].
+func (s *KV) Has(ctx context.Context, keys ...string) (blob.KeySet, error) {
 	s.μ.Lock()
 	defer s.μ.Unlock()
 	if err := s.initKeyMapLocked(ctx); err != nil {
 		return nil, err
 	}
-	out := make(blob.StatMap)
+	var out blob.KeySet
 	for _, key := range keys {
-		data, _, err := s.getLocked(ctx, key)
+		_, _, err := s.getLocked(ctx, key)
 		if err == nil {
-			out[key] = blob.Stat{Size: int64(len(data))}
+			out.Add(key)
 		} else if !blob.IsKeyNotFound(err) {
 			return nil, err
 		}

--- a/storage/encoded/encoded.go
+++ b/storage/encoded/encoded.go
@@ -120,20 +120,9 @@ func (s KV) Get(ctx context.Context, key string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Stat implements part of the [blob.KV] interface.
-func (s KV) Stat(ctx context.Context, keys ...string) (blob.StatMap, error) {
-	sts, err := s.real.Stat(ctx, keys...)
-	if err != nil {
-		return nil, err
-	}
-	for key := range sts {
-		data, err := s.Get(ctx, key)
-		if err != nil {
-			return nil, err
-		}
-		sts[key] = blob.Stat{Size: int64(len(data))}
-	}
-	return sts, nil
+// Has implements part of the [blob.KV] interface.
+func (s KV) Has(ctx context.Context, keys ...string) (blob.KeySet, error) {
+	return s.real.Has(ctx, keys...)
 }
 
 // Put implements part of the [blob.KV] interface.

--- a/storage/filestore/filestore.go
+++ b/storage/filestore/filestore.go
@@ -118,13 +118,12 @@ func (s KV) Get(_ context.Context, key string) ([]byte, error) {
 	return bits, nil
 }
 
-// Stat implements part of [blob.KV].
-func (s KV) Stat(ctx context.Context, keys ...string) (blob.StatMap, error) {
-	out := make(blob.StatMap)
+// Has implements part of [blob.KV].
+func (s KV) Has(ctx context.Context, keys ...string) (blob.KeySet, error) {
+	var out blob.KeySet
 	for _, key := range keys {
-		fi, err := os.Stat(s.keyPath(key))
-		if err == nil {
-			out[key] = blob.Stat{Size: fi.Size()}
+		if _, err := os.Stat(s.keyPath(key)); err == nil {
+			out.Add(key)
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("key %q: %w", key, err)
 		}


### PR DESCRIPTION
The first commit is the substance; the rest are updates to usage.

As noted in 5f64dc6f, having to report the size had the side effect of making
this API inefficient for key space synchronization. Since I don't have a real
need for size right now anyway, rework the method as a plain existence check.
Update the test harness.

If size is needed later, that can be a separate method.
