### PR TITLE
blob: update signature of List to return an iterator

### DIFF
--- a/blob/memstore/memstore.go
+++ b/blob/memstore/memstore.go
@@ -96,7 +96,7 @@ func New(newKV func() blob.KV) *Store {
 // contents of a Store are not persisted. All operations on a memstore are safe
 // for concurrent use by multiple goroutines.
 type KV struct {
-	μ sync.Mutex
+	μ sync.RWMutex
 	m *stree.Tree[entry]
 }
 
@@ -132,8 +132,8 @@ func (s *KV) Snapshot(m map[string]string) map[string]string {
 	if m == nil {
 		m = make(map[string]string)
 	}
-	s.μ.Lock()
-	defer s.μ.Unlock()
+	s.μ.RLock()
+	defer s.μ.RUnlock()
 	for e := range s.m.Inorder {
 		m[e.key] = e.val
 	}
@@ -154,8 +154,8 @@ func (s *KV) Init(m map[string]string) *KV {
 
 // Get implements part of [blob.KV].
 func (s *KV) Get(_ context.Context, key string) ([]byte, error) {
-	s.μ.Lock()
-	defer s.μ.Unlock()
+	s.μ.RLock()
+	defer s.μ.RUnlock()
 
 	if e, ok := s.m.Get(entry{key: key}); ok {
 		return []byte(e.val), nil
@@ -165,8 +165,8 @@ func (s *KV) Get(_ context.Context, key string) ([]byte, error) {
 
 // Has implements part of [blob.KV].
 func (s *KV) Has(_ context.Context, keys ...string) (blob.KeySet, error) {
-	s.μ.Lock()
-	defer s.μ.Unlock()
+	s.μ.RLock()
+	defer s.μ.RUnlock()
 	out := make(blob.KeySet)
 	for _, key := range keys {
 		if _, ok := s.m.Get(entry{key: key}); ok {
@@ -190,17 +190,6 @@ func (s *KV) Put(_ context.Context, opts blob.PutOptions) error {
 	return nil
 }
 
-// Size implements part of [blob.KV].
-func (s *KV) Size(_ context.Context, key string) (int64, error) {
-	s.μ.Lock()
-	defer s.μ.Unlock()
-
-	if e, ok := s.m.Get(entry{key: key}); ok {
-		return int64(len(e.val)), nil
-	}
-	return 0, blob.KeyNotFound(key)
-}
-
 // Delete implements part of [blob.KV].
 func (s *KV) Delete(_ context.Context, key string) error {
 	s.μ.Lock()
@@ -215,8 +204,8 @@ func (s *KV) Delete(_ context.Context, key string) error {
 // List implements part of [blob.KV].
 func (s *KV) List(_ context.Context, start string) iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {
-		s.μ.Lock()
-		defer s.μ.Unlock()
+		s.μ.RLock()
+		defer s.μ.RUnlock()
 
 		for e := range s.m.InorderAfter(entry{key: start}) {
 			if !yield(e.key, nil) {
@@ -228,7 +217,7 @@ func (s *KV) List(_ context.Context, start string) iter.Seq2[string, error] {
 
 // Len implements part of [blob.KV].
 func (s *KV) Len(context.Context) (int64, error) {
-	s.μ.Lock()
-	defer s.μ.Unlock()
+	s.μ.RLock()
+	defer s.μ.RUnlock()
 	return int64(s.m.Len()), nil
 }

--- a/blob/memstore/memstore_test.go
+++ b/blob/memstore/memstore_test.go
@@ -77,3 +77,27 @@ func TestConsistency(t *testing.T) {
 		}
 	}
 }
+
+func TestReadWhileListing(t *testing.T) {
+	ctx := context.Background()
+
+	want := map[string]string{
+		"cheddar": "ham",
+		"babou":   "dozing",
+		"olive":   "slumpt",
+		"monty":   "grumpus",
+		"luna":    "buckwild",
+	}
+	kv := memstore.NewKV().Init(want)
+	for key, err := range kv.List(ctx, "") {
+		if err != nil {
+			t.Fatalf("Unexpected error from list: %v", err)
+		}
+		got, err := kv.Get(ctx, key)
+		if err != nil {
+			t.Errorf("Get %q: unexpected error: %v", key, err)
+		} else if string(got) != want[key] {
+			t.Errorf("Get %q: got %q, want %q", key, got, want[key])
+		}
+	}
+}

--- a/blob/store.go
+++ b/blob/store.go
@@ -128,6 +128,10 @@ type KVCore interface {
 	//     }
 	//     // ... process key
 	//  }
+	//
+	// It must be safe to call Get, Has, List, and Len during iteration.
+	// A caller should not attempt to modify the store while listing, unless the
+	// storage implementation documents that it is safe to do so.
 	List(ctx context.Context, start string) iter.Seq2[string, error]
 
 	// Len reports the number of keys currently in the store.

--- a/blob/store.go
+++ b/blob/store.go
@@ -110,8 +110,15 @@ type KVCore interface {
 	Delete(ctx context.Context, key string) error
 
 	// List returns an iterator over each key in the store greater than or equal
-	// to start, in lexicographic order.  Each pair reported by the iterator
-	// must have a nil error, except possibly the last.
+	// to start, in lexicographic order.
+	//
+	// Requirements:
+	//
+	// Each pair reported by the iterator MUST be either a valid key and a nil
+	// error, or an empty key and a non-nil error.
+	//
+	// After the iterator reports an error, it MUST immediately return, even if
+	// the yield function reports true.
 	//
 	// The caller should check the error as part of iteration:
 	//
@@ -121,7 +128,6 @@ type KVCore interface {
 	//     }
 	//     // ... process key
 	//  }
-	//
 	List(ctx context.Context, start string) iter.Seq2[string, error]
 
 	// Len reports the number of keys currently in the store.

--- a/storage/encoded/encoded.go
+++ b/storage/encoded/encoded.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"iter"
 
 	"github.com/creachadair/ffs/blob"
 )
@@ -144,8 +145,8 @@ func (s KV) Delete(ctx context.Context, key string) error {
 
 // List implements part of the [blob.KV] interface.
 // It delegates directly to the underlying store.
-func (s KV) List(ctx context.Context, start string, f func(string) error) error {
-	return s.real.List(ctx, start, f)
+func (s KV) List(ctx context.Context, start string) iter.Seq2[string, error] {
+	return s.real.List(ctx, start)
 }
 
 // Len implements part of the [blob.KV] interface.

--- a/storage/wbstore/wbstore_test.go
+++ b/storage/wbstore/wbstore_test.go
@@ -117,12 +117,14 @@ func TestStore(t *testing.T) {
 		t.Helper()
 		sort.Strings(want)
 		var got []string
-		if err := m.List(ctx, "", func(key string) error {
+		for key, err := range m.List(ctx, "") {
+			if err != nil {
+				t.Errorf("List: unexpected error: %v", err)
+				break
+			}
 			got = append(got, key)
-			return nil
-		}); err != nil {
-			t.Errorf("List: unexpected error: %v", err)
-		} else if diff := cmp.Diff(got, want); diff != "" {
+		}
+		if diff := cmp.Diff(got, want); diff != "" {
 			t.Errorf("List (-got, +want):\n%s", diff)
 		}
 	}

--- a/storage/wbstore/writer.go
+++ b/storage/wbstore/writer.go
@@ -136,12 +136,12 @@ func (w *writer) run(ctx context.Context) error {
 		// List all the buffered keys and shuffle them so that we don't hammer
 		// the same shards of the underlying store in cases where that matters.
 		work = work[:0]
-		if err := w.buf.List(ctx, "", func(key string) error {
+		for key, err := range w.buf.List(ctx, "") {
+			if err != nil {
+				log.Printf("DEBUG :: error scanning buffer: %v", err)
+				continue
+			}
 			work = append(work, key)
-			return nil
-		}); err != nil {
-			log.Printf("DEBUG :: error scanning buffer: %v", err)
-			continue
 		}
 		rand.Shuffle(len(work), func(i, j int) { work[i], work[j] = work[j], work[i] })
 


### PR DESCRIPTION
Instead of a callback for keys, return an iterator the caller can pull.
To deal with errors, borrow a trick from @danderson, to report two values per
yield: In case of error, the List implementation yields a pair with a non-nil
error before terminating iteration. Otherwise, it yields a (key, nil) pair for
each valid key in the requested range.
